### PR TITLE
Twogether PC 버전 확장 및 UI 리팩토링

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "browser-image-compression": "^2.0.2",
+        "lodash": "^4.17.21",
         "lucide-react": "^0.525.0",
         "next": "15.3.5",
         "react": "^19.0.0",
@@ -20,6 +21,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@tailwindcss/postcss": "^4",
+        "@types/lodash": "^4.17.21",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -1296,6 +1298,13 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-FOvQ0YPD5NOfPgMzJihoT+Za5pdkDJWcbpuj1DjaKZIr/gxodQjY/uWEFlTNqW2ugXHUiL8lRQgw63dzKHZdeQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4492,6 +4501,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "browser-image-compression": "^2.0.2",
+    "lodash": "^4.17.21",
     "lucide-react": "^0.525.0",
     "next": "15.3.5",
     "react": "^19.0.0",
@@ -21,6 +22,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
+    "@types/lodash": "^4.17.21",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/src/app/(user)/find-email/page.tsx
+++ b/src/app/(user)/find-email/page.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
 
 function FindEmail() {
   return (
-    <main className="mx-4 mb-20">
+    <main className="mx-4 lg:px-20 mb-20">
       <p className="text-center">이메일 찾기 페이지입니다.</p>
       <p className="mb-5 text-xs text-gray-350 text-center">본인 확인을 위해 이름과 휴대폰 번호를 입력해 주세요.</p>
       <div className="mx-4">

--- a/src/app/(user)/login/page.tsx
+++ b/src/app/(user)/login/page.tsx
@@ -23,7 +23,7 @@ export const metadata: Metadata = {
 function Login() {
   return (
     <>
-      <main className="mx-4 mb-20">
+      <main className="mx-4 lg:px-20 mb-20">
         <h2 className={`mt-5 text-2xl text-center ${JudsonFont.className}`}>LOGIN</h2>
         <div className="flex flex-col px-4">
           <Suspense>

--- a/src/app/(user)/resend-verification/page.tsx
+++ b/src/app/(user)/resend-verification/page.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
 function ResendVerification() {
   return (
     <>
-      <main className="mx-4 mb-20">
+      <main className="mx-4 lg:px-20 mb-20">
         <p className="text-center">이메일 재인증 페이지입니다.</p>
         <p className="mb-5 text-xs text-gray-350 text-center">회원 가입 시 사용하신 이메일을 입력해 주세요.</p>
         <div className="mx-4">

--- a/src/app/(user)/signup/layout.tsx
+++ b/src/app/(user)/signup/layout.tsx
@@ -18,7 +18,7 @@ function Signup({
 
   return (
     <>
-      <main className="h-full mx-4">
+      <main className="lg:px-20 mx-4 mb-20">
         <h2 className={`mt-5 text-2xl text-center ${JudsonFont.className}`}>SIGN UP</h2>
         <div className="flex gap-4 justify-center py-6 border-b-2 border-gray-350">
           <span className={path === '/signup/terms' ? 'text-black' : 'text-gray-250'}>1. 약관동의</span>

--- a/src/app/HeaderLayout.tsx
+++ b/src/app/HeaderLayout.tsx
@@ -3,12 +3,14 @@
 import SubHeader from '@/components/layout/SubHeader';
 import Header from '@/components/layout/Header';
 import { usePathname } from 'next/navigation';
+import { useWindowWidth } from '@/hooks/useWindowWidth';
 
-export default function Mainlayout() {
+export default function HeaderLayout() {
+  const path = usePathname();
+  const width = useWindowWidth();
+
   let useSubHeader = false;
   let title: string | undefined = undefined;
-
-  const path = usePathname();
 
   // 1path를 '/' 기준으로 나눔
   // segments 예: ['shop', 'shortSleeve', '456']
@@ -47,6 +49,8 @@ export default function Mainlayout() {
     useSubHeader = true;
     title = 'Q&A';
   }
+
+  if (width >= 768) return <Header />;
 
   return <>{useSubHeader ? <SubHeader title={title} /> : <Header />}</>;
 }

--- a/src/app/ProductMainPage.tsx
+++ b/src/app/ProductMainPage.tsx
@@ -24,7 +24,6 @@ export default async function ProductMainPage({ category }: ProductMainPageProps
   if (data.ok === 0 || !data.item || data.item.length === 0) {
     return null;
   }
-  console.log(data);
 
   // best, sale 상품을 렌덤으로 보여줌
   function shuffleArray(array: Product[]): Product[] {

--- a/src/app/ProductMainPage.tsx
+++ b/src/app/ProductMainPage.tsx
@@ -13,6 +13,8 @@ export default async function ProductMainPage({ category }: ProductMainPageProps
     customQuery = encodeURIComponent(JSON.stringify({ 'extra.isBest': true }));
   } else if (category === 'sale') {
     customQuery = encodeURIComponent(JSON.stringify({ 'extra.isSale': true }));
+  } else if (category === 'all') {
+    customQuery = encodeURIComponent(JSON.stringify({}));
   } else {
     return null;
   }
@@ -22,6 +24,7 @@ export default async function ProductMainPage({ category }: ProductMainPageProps
   if (data.ok === 0 || !data.item || data.item.length === 0) {
     return null;
   }
+  console.log(data);
 
   // best, sale 상품을 렌덤으로 보여줌
   function shuffleArray(array: Product[]): Product[] {
@@ -29,12 +32,14 @@ export default async function ProductMainPage({ category }: ProductMainPageProps
   }
 
   const shuffled = shuffleArray(data.item);
-  const selected = shuffled.slice(0, 2);
+  let selected;
+  if (category === 'all') selected = shuffled.slice(0, 12);
+  else selected = shuffled.slice(0, 2);
 
   return (
     <>
       {selected.map((item) => (
-        <ProductCardItem key={item._id} productType={category} data={[item]} />
+        <ProductCardItem key={item._id} productType={category} data={[item]} autoplay={category !== 'all'} />
       ))}
     </>
   );

--- a/src/app/brand/page.tsx
+++ b/src/app/brand/page.tsx
@@ -18,9 +18,8 @@ export const metadata: Metadata = {
 
 export default function BrandPage() {
   return (
-    <main>
-      <Image src="/images/model/main-model1.png" alt="브랜드 모델" width={768} height={512} className="w-full h-auto" />
-      <section className="my-12 mx-4">
+    <main className="mb-20">
+      <section className="my-12 mx-4 lg:text-center">
         <h2 className={`${JudsonFont.className} text-2xl`}>Twogether</h2>
         <p className="mt-4">하루를 함께 마무리하고</p>
         <p>
@@ -33,7 +32,7 @@ export default function BrandPage() {
         <p>그 밤이 더 따뜻하고 부드럽게 감싸지길 바라며</p>
         <p>정성스럽게 만들기 시작했습니다.</p>
       </section>
-      <Image src="/images/model/main-model2.png" width={768} height={500} alt="브랜드 모델" />
+      <Image src="/images/model/main-model2.png" width={768} height={500} alt="브랜드 모델" className="w-full" />
       <section className="flex flex-col justify-center items-center my-12 mx-4">
         <h2 className={`${JudsonFont.className} text-2xl`}>Twogether, </h2>
         <p>당신의 밤과 함께</p>
@@ -48,8 +47,8 @@ export default function BrandPage() {
         <p>꼼꼼한 제작 과정을 통해 신뢰를 만듭니다.</p>
       </section>
       <div className="relative">
-        <Image src="/images/model/main-model3.png" width={768} height={500} alt="브랜드 모델" />
-        <p className={`absolute bottom-5 ${JudsonFont.className} text-2xl text-white`}>Twogether</p>
+        <Image src="/images/model/main-model3.png" width={768} height={500} alt="브랜드 모델" className="w-full" />
+        <p className={`absolute bottom-5 left-5 ${JudsonFont.className} text-2xl text-white`}>Twogether</p>
       </div>
     </main>
   );

--- a/src/app/community/CommunityPage.tsx
+++ b/src/app/community/CommunityPage.tsx
@@ -125,7 +125,7 @@ export default function CommunityPage({ boardType }: CommunityPageProps) {
   // 8. 메인 렌더링
   return (
     <>
-      <div className="sticky top-16 bg-white">
+      <div className="sticky top-16 xl:top-20 bg-white/80">
         {boardType !== 'qna' && (
           <div className="flex gap-2.5 justify-center py-2">
             <Link href="/community/notice">
@@ -140,10 +140,10 @@ export default function CommunityPage({ boardType }: CommunityPageProps) {
             </Link>
           </div>
         )}
-
-        {/* 검색 폼 */}
-        <SearchForm />
       </div>
+
+      {/* 검색 폼 */}
+      <SearchForm />
 
       {loading ? (
         <div className="text-center py-8">
@@ -171,11 +171,11 @@ export default function CommunityPage({ boardType }: CommunityPageProps) {
 
           {/* 이벤트 게시글 목록 */}
           {isEventBoard && posts.length > 0 && (
-            <>
-              {posts.map((post, i) => (
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 place-items-center mx-10">
+              {posts.map((post) => (
                 <EventList key={post._id} post={post} boardType={boardType} />
               ))}
-            </>
+            </div>
           )}
 
           {/* 게시글이 없을 때 */}

--- a/src/app/eventSlider.tsx
+++ b/src/app/eventSlider.tsx
@@ -25,20 +25,31 @@ export default function EventSlider() {
 
   return (
     <>
-      <div className="grid grid-cols-2 gap-4">
-        {eventSilderState.map((slide) => {
-          return (
-            <Link key={slide._id} href={`/community/event/${slide._id}`}>
-              <Image
-                src={`/images/event/event_${slide._id}.png`}
-                alt={slide.content}
-                className="w-full"
-                width="469"
-                height="216"
-              />
-            </Link>
-          );
-        })}
+      <div className="grid grid-cols-3 gap-4 max-lg:hidden">
+        {eventSilderState.slice(0, 3).map((slide) => (
+          <Link key={slide._id} href={`/community/event/${slide._id}`}>
+            <Image
+              src={`/images/event/event_${slide._id}.png`}
+              alt={slide.content}
+              className="w-full"
+              width="469"
+              height="216"
+            />
+          </Link>
+        ))}
+      </div>
+      <div className="grid grid-cols-2 gap-4 lg:hidden">
+        {eventSilderState.map((slide) => (
+          <Link key={slide._id} href={`/community/event/${slide._id}`}>
+            <Image
+              src={`/images/event/event_${slide._id}.png`}
+              alt={slide.content}
+              className="w-full"
+              width="469"
+              height="216"
+            />
+          </Link>
+        ))}
       </div>
     </>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,14 +3,14 @@ import Footer from '@/components/layout/Footer';
 import './globals.css';
 import localFont from 'next/font/local';
 
+import Script from 'next/script';
+import HeaderLayout from '@/app/HeaderLayout';
+
 const pretendard = localFont({
   src: '../../public/font/PretendardVariable.ttf',
   display: 'swap', // 폰트 로딩
   weight: '45 920',
 });
-
-import Mainlayout from '@/app/Mainlayout';
-import Script from 'next/script';
 
 export default function RootLayout({
   children,
@@ -22,8 +22,10 @@ export default function RootLayout({
       <Script src="https://developers.kakao.com/sdk/js/kakao.js" strategy="afterInteractive" />
       <body className={`flex flex-col items-center justify-center min-h-screen bg-white ${pretendard.className} `}>
         <div className="flex flex-col relative w-full min-h-dvh bg-white">
-          <Mainlayout />
-          <div className="flex-1 mx-auto lg:px-8 w-full max-w-7xl min-h-[calc(100dvh-128px)]">{children}</div>
+          <HeaderLayout />
+          <div className="flex-1 mx-auto lg:px-8 w-full max-w-7xl min-h-[calc(100dvh-128px)] md:min-h-[calc(100dvh-64px)] xl:min-h-[calc(100dvh-80px)]">
+            {children}
+          </div>
           <Footer />
           <Navigation />
         </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,9 +21,9 @@ export default function RootLayout({
     <html lang="ko">
       <Script src="https://developers.kakao.com/sdk/js/kakao.js" strategy="afterInteractive" />
       <body className={`flex flex-col items-center justify-center min-h-screen bg-white ${pretendard.className} `}>
-        <div className="flex flex-col relative w-full max-w-[768px] min-h-dvh bg-white">
+        <div className="flex flex-col relative w-full min-h-dvh bg-white">
           <Mainlayout />
-          <div className="flex-1 min-h-[calc(100dvh-128px)]">{children}</div>
+          <div className="flex-1 mx-auto lg:px-8 w-full max-w-7xl min-h-[calc(100dvh-128px)]">{children}</div>
           <Footer />
           <Navigation />
         </div>

--- a/src/app/my-page/MypageMain.tsx
+++ b/src/app/my-page/MypageMain.tsx
@@ -25,7 +25,7 @@ function MypageMain() {
           <EditProfileImage />
           <span>{user?.name} 님</span>
         </div>
-        <div className="flex justify-between items-center p-5 rounded-lg border-[.0625rem] border-gray-150 text-sm">
+        <div className="flex justify-between items-center p-5 md:px-10 lg:px-20 rounded-lg border-[.0625rem] border-gray-150 text-sm">
           <div className="flex flex-col gap-1 items-center">
             <span className="text-lg">0</span>
             <span>입금 전</span>

--- a/src/app/my-page/edit-profile/form/page.tsx
+++ b/src/app/my-page/edit-profile/form/page.tsx
@@ -14,13 +14,11 @@ export const metadata: Metadata = {
 
 function Form() {
   return (
-    <>
-      <div className="">
-        <p className="text-center">개인 정보를 입력해 주세요.</p>
-        <p className="mb-5 text-xs text-gray-350 text-center">[완료] 버튼을 누르면 입력하신 정보가 반영됩니다. </p>
-        <EditProfileForm />
-      </div>
-    </>
+    <div>
+      <p className="text-center">개인 정보를 입력해 주세요.</p>
+      <p className="mb-5 text-xs text-gray-350 text-center">[완료] 버튼을 누르면 입력하신 정보가 반영됩니다. </p>
+      <EditProfileForm />
+    </div>
   );
 }
 

--- a/src/app/my-page/edit-profile/layout.tsx
+++ b/src/app/my-page/edit-profile/layout.tsx
@@ -18,7 +18,7 @@ function EditProfile({
 
   return (
     <>
-      <main className="h-full mx-4">
+      <main className="mx-4">
         <h2 className={`text-2xl text-center ${JudsonFont.className}`}>EDIT PROFILE</h2>
         <div className="flex gap-4 justify-center py-6 border-b-2 border-gray-350">
           <span className={path === '/my-page/edit-profile/verify' ? 'text-black' : 'text-gray-250'}>1. 본인인증</span>

--- a/src/app/my-page/edit-profile/layout.tsx
+++ b/src/app/my-page/edit-profile/layout.tsx
@@ -27,7 +27,7 @@ function EditProfile({
           <ChevronRight color={'#B0B0B0'} />
           <span className={path === '/my-page/edit-profile/success' ? 'text-black' : 'text-gray-250'}>3. 수정완료</span>
         </div>
-        <div className="py-6 px-4">{children}</div>
+        <div className="py-6 px-4 lg:px-20">{children}</div>
       </main>
     </>
   );

--- a/src/app/my-page/edit-profile/success/page.tsx
+++ b/src/app/my-page/edit-profile/success/page.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
 function Success() {
   return (
     <>
-      <div className="min-h-full flex flex-col gap-4 items-center">
+      <div className="flex flex-col gap-4 items-center">
         <p className="text-center">
           개인 정보 수정이 완료되었습니다.
           <br />

--- a/src/app/my-page/edit-profile/verify/page.tsx
+++ b/src/app/my-page/edit-profile/verify/page.tsx
@@ -14,15 +14,11 @@ export const metadata: Metadata = {
 
 function Verify() {
   return (
-    <>
-      <div className="">
-        <p className="text-center">정보 보호를 위해 이메일 인증이 필요합니다.</p>
-        <p className="mb-5 text-xs text-gray-350 text-center">
-          고객님의 소중한 정보를 안전하게 지키기 위한 단계입니다.
-        </p>
-        <VerifyForm />
-      </div>
-    </>
+    <div>
+      <p className="text-center">정보 보호를 위해 이메일 인증이 필요합니다.</p>
+      <p className="mb-5 text-xs text-gray-350 text-center">고객님의 소중한 정보를 안전하게 지키기 위한 단계입니다.</p>
+      <VerifyForm />
+    </div>
   );
 }
 

--- a/src/app/my-page/review/ReviewImagesModal.tsx
+++ b/src/app/my-page/review/ReviewImagesModal.tsx
@@ -28,7 +28,7 @@ function ReviewImagesModal({ isOpen, setOpen, images }: ReviewImagesModalProps) 
         onClick={() => {
           setOpen(false);
         }}
-        className="fixed flex h-dvh min-w-[400px] max-w-[768px] mx-auto inset-0 justify-center items-center bg-black/70 z-10"
+        className="fixed flex h-dvh inset-0 justify-center items-center bg-black/70 z-10"
       >
         <div
           role="dialog"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import EventSlider from '@/app/eventSlider';
 import Image from 'next/image';
 import ProductMainPage from '@/app/ProductMainPage';
 import LinkButton from '@/components/common/LinkButton';
+import Link from 'next/link';
 
 const JudsonFont = Judson({
   subsets: ['latin'],
@@ -124,6 +125,9 @@ export default function Home() {
           <h2 className={`text-2xl font-bold my-6 ${JudsonFont.className}`}>EVENT</h2>
           <div className="mx-4">
             <EventSlider />
+            <Link href={'/community/event'} className="block mt-4 text-right hover:underline">
+              이벤트 더보기
+            </Link>
           </div>
         </section>
         {/* 이벤트 섹션 종료 */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -27,44 +27,46 @@ export default function Home() {
     <>
       <Image
         src="/images/model/main-model1.png"
-        className="w-full"
-        width="480"
-        height="322"
+        className="w-full lg:h-100 object-cover object-top"
+        width="900"
+        height="900"
         alt="여성 잠옷 모델 이미지"
       />
       <main className="text-center flex flex-col gap-5 mt-5 mb-20">
         {/* 배스트 섹션 시작 */}
         <section>
-          <h2 className={`text-2xl font-bold my-6 ${JudsonFont.className}`}>BEST</h2>
-          <div className="relative mt-4">
-            <div className="h-[21.875rem] overflow-hidden">
-              <Image
-                src="/images/model/main-model3.png"
-                className="w-full h-full object-cover scale-120 relative right-10 top-10"
-                width="888"
-                height="422"
-                alt="여성 잠옷 모델 이미지"
-              />
+          <h2 className={`text-2xl font-bold my-6 ${JudsonFont.className} lg:hidden`}>BEST</h2>
+          <div className="lg:flex">
+            <div className="flex-1 relative mt-4">
+              <div className="h-[21.875rem] lg:h-80 overflow-hidden">
+                <Image
+                  src="/images/model/main-model3.png"
+                  className="w-full h-full object-cover scale-120 relative right-10 top-10"
+                  width="888"
+                  height="422"
+                  alt="여성 잠옷 모델 이미지"
+                />
+              </div>
+              <div className="absolute right-[2.625rem] top-1/2 -translate-y-1/2 text-white">
+                <p className={`${JudsonFont.className} text-2xl font-bold`}>Twogether</p>
+                <p className={`${JudsonFont.className} text-2xl mb-4`}>The Last Episode</p>
+                <LinkButton href="/shop/best" lang="eng">
+                  GO BEST
+                </LinkButton>
+              </div>
             </div>
-            <div className="absolute right-[2.625rem] top-1/2 -translate-y-1/2 text-white">
-              <p className={`${JudsonFont.className} text-2xl font-bold`}>Twogether</p>
-              <p className={`${JudsonFont.className} text-2xl mb-4`}>The Last Episode</p>
-              <LinkButton href="/shop/best" lang="eng">
-                GO BEST
-              </LinkButton>
-            </div>
-          </div>
 
-          <ul className="grid grid-cols-2 gap-4 my-6 mx-4">
-            <ProductMainPage category="best" />
-          </ul>
+            <ul className="flex-1 grid grid-cols-2 gap-4 my-6 mx-4">
+              <ProductMainPage category="best" />
+            </ul>
+          </div>
         </section>
         {/* 배스트 섹션 종로 */}
 
         {/* 세일 섹션 시작 */}
         <section>
-          <h2 className={`text-2xl font-bold my-6 ${JudsonFont.className}`}>SALE</h2>
-          <div className="relative mt-4">
+          <h2 className={`text-2xl font-bold my-6 ${JudsonFont.className} lg:hidden`}>SALE</h2>
+          <div className="relative mt-4 lg:hidden">
             <div className="h-[21.875rem] overflow-hidden">
               <Image
                 src="/images/model/main-model2.png"
@@ -83,11 +85,39 @@ export default function Home() {
             </div>
           </div>
 
-          <ul className="grid grid-cols-2 gap-4 my-6 mx-4">
-            <ProductMainPage category="sale" />
-          </ul>
+          <div className="lg:flex">
+            <ul className="flex-1 grid grid-cols-2 gap-4 my-6 mx-4">
+              <ProductMainPage category="sale" />
+            </ul>
+            <div className="flex-1 relative mt-4 max-lg:hidden">
+              <div className="lg:h-80 overflow-hidden">
+                <Image
+                  src="/images/model/main-model2.png"
+                  className="w-full h-full object-cover relative scale-120 left-10 top-10"
+                  width="888"
+                  height="452"
+                  alt="여성 잠옷 모델 이미지"
+                />
+              </div>
+              <div className="absolute left-[2.625rem] top-1/2 -translate-y-1/2 text-white">
+                <p className={`${JudsonFont.className} text-2xl font-bold`}>Twogether</p>
+                <p className={`${JudsonFont.className} text-2xl mb-4`}>The Last Episode</p>
+                <LinkButton href="/shop/best" lang="eng">
+                  TO SALE
+                </LinkButton>
+              </div>
+            </div>
+          </div>
         </section>
         {/* 세일 섹션 종료 */}
+
+        {/* 전체 섹션 시작 (PC) */}
+        <section>
+          <ul className="flex-1 grid grid-cols-4 gap-4 my-6 mx-4 max-lg:hidden">
+            <ProductMainPage category="all" />
+          </ul>
+        </section>
+        {/* 전체 섹션 시작 (PC) */}
 
         {/* 이벤트 섹션 시작 */}
         <section>

--- a/src/app/shop/[productType]/[id]/Overview.tsx
+++ b/src/app/shop/[productType]/[id]/Overview.tsx
@@ -7,13 +7,13 @@ const JudsonFont = Judson({
   weight: '700',
 });
 
-export default function OverviewPage({ productType, product }: ProductDetails) {
+export default function OverviewPage({ product }: ProductDetails) {
   return (
     <>
-      <div>
+      <div className="w-full lg:w-[80%] place-self-center">
         <h2 className={`${JudsonFont.className} font-bold text-4xl text-center text-(--color-primary)`}>Twogether</h2>
         <p className="text-center my-4">{product.content}</p>
-        <ul className="flex flex-col gap-4  w-full">
+        <ul className="flex flex-col gap-4 text-center w-full">
           {product.mainImages.map((item) => {
             return (
               <li key={item._id}>
@@ -33,10 +33,10 @@ export default function OverviewPage({ productType, product }: ProductDetails) {
           <p>{product.content}</p>
         </div>
 
-        <ul className="flex flex-col gap-4  w-full">
+        <ul className="flex flex-col gap-4 w-full">
           {product.extra.productImg.map((item, index) => (
             <li key={`productImg-${index}`}>
-              <Image src={item} width={1000} height={1000} alt="상품 설명" />
+              <Image src={item} width={1600} height={1600} alt="상품 설명" className="w-full" />
             </li>
           ))}
         </ul>

--- a/src/app/shop/[productType]/[id]/ProductTabs.tsx
+++ b/src/app/shop/[productType]/[id]/ProductTabs.tsx
@@ -37,7 +37,7 @@ export default function ProductTabs({ productType, product }: ProductDetails) {
 
   return (
     <div className="m-4 relative">
-      <nav className="my-6 sticky top-15 bg-(--color-white)">
+      <nav className="my-6 sticky top-16 xl:top-20 bg-white/80">
         <ul className="grid grid-cols-4 justify-between items-center gap-4  border-b-1 border-black/1">
           {tabs.map((tab, index) => (
             <li

--- a/src/app/shop/[productType]/page.tsx
+++ b/src/app/shop/[productType]/page.tsx
@@ -46,6 +46,8 @@ export default async function productPage({ params }: ListPageProps) {
     customQuery = encodeURIComponent(JSON.stringify({ 'extra.isBest': true }));
   } else if (productType === 'sale') {
     customQuery = encodeURIComponent(JSON.stringify({ 'extra.isSale': true }));
+  } else if (productType === 'all') {
+    customQuery = encodeURIComponent(JSON.stringify({}));
   } else {
     customQuery = encodeURIComponent(JSON.stringify({ 'extra.category': `${productType}` }));
   }
@@ -85,7 +87,7 @@ export default async function productPage({ params }: ListPageProps) {
       ) : (
         <>
           {/* 상품 렌더링 시작 */}
-          <ul className="grid grid-cols-2 gap-4 my-6">
+          <ul className="grid grid-cols-2 lg:grid-cols-4 gap-4 my-6">
             {data.item.map((product) => {
               return (
                 <ProductCardItemLayout
@@ -98,7 +100,7 @@ export default async function productPage({ params }: ListPageProps) {
           </ul>
         </>
       )}
-      {/* 상품작렌더링 종료 */}
+      {/* 상품 렌더링 종료 */}
     </>
   );
 }

--- a/src/components/common/Alert.tsx
+++ b/src/components/common/Alert.tsx
@@ -52,7 +52,7 @@ function Alert({ isOpen, setOpen, replacePath = null, children }: AlertProps) {
   return (
     <>
       {isOpen && (
-        <div className="fixed flex h-dvh min-w-[25rem] max-w-[48rem] mx-auto inset-0 justify-center items-center bg-black/50 z-10">
+        <div className="fixed flex h-dvh mx-auto inset-0 justify-center items-center bg-black/50 z-10">
           <div
             role="dialog"
             className="flex flex-col gap-8 items-center p-8 w-[90%] max-w-[25rem] rounded-4xl bg-white z-10"

--- a/src/components/common/Dialog.tsx
+++ b/src/components/common/Dialog.tsx
@@ -30,13 +30,10 @@ function Dialog({ title, isOpen, setOpen, children }: DialogProps) {
 
   return (
     <>
-      <div
-        hidden={!isOpen}
-        className="fixed flex h-dvh min-w-[400px] max-w-[768px] mx-auto inset-0 justify-center items-center bg-black/50 z-10"
-      >
+      <div hidden={!isOpen} className="fixed flex h-dvh w-full justify-center items-center bg-black/50 z-10">
         <div
           role="dialog"
-          className="flex flex-col p-8 w-[80%] h-[80%] rounded-4xl bg-white z-10 animate-fade-in-scale"
+          className="flex flex-col p-8 lg:p-12 w-[80%] lg:w-[60%] h-[80%] lg:h-[60%] rounded-4xl bg-white z-10 animate-fade-in-scale"
         >
           <div className="flex w-full mb-5">
             <h2 className="flex-1 text-xl font-bold">{title}</h2>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -22,13 +22,15 @@ function Footer() {
 
   return (
     <>
-      <footer className="content-center px-5 h-44 w-full bg-gray-550 text-gray-250 pb-16">
-        <p className={`${JudsonFont.className}`}>Twogether</p>
-        <div className="text-xs">
-          <button onClick={handleClickPolicy}>개인정보 처리 방침</button> |{' '}
-          <button onClick={handleClickTermsOpen}>사이트 이용 약관</button>
+      <footer className="content-center px-5 h-44 md:h-30 w-full bg-gray-550 text-gray-250 max-md:pb-16">
+        <div className="mx-auto px-4 lg:px-16 max-w-7xl">
+          <p className={`${JudsonFont.className}`}>Twogether</p>
+          <div className="text-xs">
+            <button onClick={handleClickPolicy}>개인정보 처리 방침</button> |{' '}
+            <button onClick={handleClickTermsOpen}>사이트 이용 약관</button>
+          </div>
+          <small className="text-xs">© 2025 Twogether. All rights reserved.</small>
         </div>
-        <small className="text-xs">© 2025 Twogether. All rights reserved.</small>
       </footer>
       <Dialog isOpen={isPolicyOpen} setOpen={setPolicyOpen} title="개인정보 처리 방침">
         <div className="flex flex-col gap-2 text-xs">

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -4,6 +4,7 @@ import { Judson } from 'next/font/google'; // 구글 폰트 사용
 import useUserStore from '@/stores/useUserStore';
 import { useState } from 'react';
 import Alert from '@/components/common/Alert';
+import Link from 'next/link';
 
 const JudsonFont = Judson({
   subsets: ['latin'],
@@ -29,13 +30,27 @@ function Header() {
 
   return (
     <>
-      <header className="sticky top-0 flex justify-between h-16 w-full px-5 bg-white z-10 shadow-xs">
+      <header className="sticky top-0 flex justify-between items-center h-16 lg:h-16 xl:h-20 w-full mx-auto px-4 lg:px-16 max-w-7xl bg-white lg:bg-white/80 z-10 shadow-b-xs">
         <button
           onClick={() => router.push('/')}
           className={`content-center text-3xl text-black ${JudsonFont.className} hover:cursor-pointer`}
         >
           Twogether
         </button>
+        <ul className="flex-1 flex gap-4 place-content-end mr-4 max-md:hidden">
+          <li>
+            <Link href={'/shop/all'}>SHOP</Link>
+          </li>
+          <li>
+            <Link href={'/community/notice'}>COMMUNITY</Link>
+          </li>
+          <li>
+            <Link href={'/brand'}>ABOUT-US</Link>
+          </li>
+          <li>
+            <Link href={'/my-page'}>MY-PAGE</Link>
+          </li>
+        </ul>
         <button onClick={onCartClick} className="content-center hover:cursor-pointer">
           <ShoppingBag color="var(--color-black)" size={20} />
         </button>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,5 +1,5 @@
 import { ShoppingBag } from 'lucide-react';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { Judson } from 'next/font/google'; // 구글 폰트 사용
 import useUserStore from '@/stores/useUserStore';
 import { useState } from 'react';
@@ -14,6 +14,7 @@ const JudsonFont = Judson({
 function Header() {
   const { isLoggedIn } = useUserStore();
   const router = useRouter();
+  const path = usePathname();
   const [isAlertOpen, setIsAlertOpen] = useState(false);
   const [alertMessage, setAlertMessage] = useState('');
   const [alertReplacePath, setAlertReplacePath] = useState<string | null>(null);
@@ -30,7 +31,7 @@ function Header() {
 
   return (
     <>
-      <header className="sticky top-0 flex justify-between items-center h-16 lg:h-16 xl:h-20 w-full mx-auto px-4 lg:px-16 max-w-7xl bg-white lg:bg-white/80 z-10 shadow-b-xs">
+      <header className="sticky top-0 flex justify-between items-center h-16 xl:h-20 w-full mx-auto px-4 lg:px-16 max-w-7xl bg-white/80 z-10 shadow-b-xs">
         <button
           onClick={() => router.push('/')}
           className={`content-center text-3xl text-black ${JudsonFont.className} hover:cursor-pointer`}
@@ -39,16 +40,27 @@ function Header() {
         </button>
         <ul className="flex-1 flex gap-4 place-content-end mr-4 max-md:hidden">
           <li>
-            <Link href={'/shop/all'}>SHOP</Link>
+            <Link href={'/shop/all'} className={`${path.startsWith('/shop') && 'underline'}`}>
+              SHOP
+            </Link>
           </li>
           <li>
-            <Link href={'/community/notice'}>COMMUNITY</Link>
+            <Link href={'/community/notice'} className={`${path.startsWith('/community') && 'underline'}`}>
+              COMMUNITY
+            </Link>
           </li>
           <li>
-            <Link href={'/brand'}>ABOUT-US</Link>
+            <Link href={'/brand'} className={`${path.startsWith('/brand') && 'underline'}`}>
+              ABOUT-US
+            </Link>
           </li>
           <li>
-            <Link href={'/my-page'}>MY-PAGE</Link>
+            <Link
+              href={`${isLoggedIn ? '/my-page' : '/login?redirect=/my-page'}`}
+              className={`${path.startsWith('/my-page') && 'underline'}`}
+            >
+              MY-PAGE
+            </Link>
           </li>
         </ul>
         <button onClick={onCartClick} className="content-center hover:cursor-pointer">

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -14,7 +14,7 @@ function Navigation() {
   }, []);
 
   return (
-    <nav className="fixed bottom-0 w-full min-w-[400px] max-w-[768px] bg-white z-[1] shadow-2xl">
+    <nav className="fixed bottom-0 w-full min-w-[400px] max-w-[768px] bg-white z-[1] shadow-2xl md:hidden">
       <ul className="flex justify-between h-16">
         <li className="contents">
           <Link href="/menu" className="flex flex-col justify-center items-center content-center flex-1 h-full">

--- a/src/components/post/SearchForm.tsx
+++ b/src/components/post/SearchForm.tsx
@@ -33,7 +33,7 @@ export default function SearchForm() {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="flex">
+    <form onSubmit={handleSubmit} className="flex gap-4">
       <div className="flex-1 pb-4">
         <Input
           id="search"

--- a/src/components/product/ImagesSwiper.tsx
+++ b/src/components/product/ImagesSwiper.tsx
@@ -5,11 +5,12 @@ import Image from 'next/image';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import 'swiper/css';
 import { Product } from '@/types/product';
-import { Autoplay } from 'swiper/modules';
+import { A11y, Autoplay } from 'swiper/modules';
 
 interface ProductCardItemProps {
   data: Product;
   height: string;
+  autoplay: boolean;
 }
 
 /**
@@ -26,12 +27,12 @@ interface ProductCardItemProps {
  * @returns {JSX.Element} Swiper 기반 이미지 슬라이드 JSX
  */
 
-export default function ImagesSwiper({ data, height }: ProductCardItemProps) {
+export default function ImagesSwiper({ data, height, autoplay }: ProductCardItemProps) {
   return (
     <>
       <div className="swiper-container">
         <Swiper
-          modules={[Autoplay]} // 모듈 등록, 아래 파일 사용시
+          modules={[autoplay ? Autoplay : A11y]} // 모듈 등록, 아래 파일 사용시
           loop={true} // 슬라이드 루프
           spaceBetween={0} // 슬라이스 사이 간격
           slidesPerView={1} // 보여질 슬라이스 수

--- a/src/components/product/ImagesSwiper.tsx
+++ b/src/components/product/ImagesSwiper.tsx
@@ -10,7 +10,7 @@ import { A11y, Autoplay } from 'swiper/modules';
 interface ProductCardItemProps {
   data: Product;
   height: string;
-  autoplay: boolean;
+  autoplay?: boolean;
 }
 
 /**

--- a/src/components/product/ProductCardItem.tsx
+++ b/src/components/product/ProductCardItem.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 interface ProductCardItemProps {
   productType?: string;
   data: Product[];
+  autoplay?: boolean;
 }
 
 /**
@@ -21,14 +22,14 @@ interface ProductCardItemProps {
  * @returns {JSX.Element} 상품 목록 UI를 포함한 JSX 엘리먼트
  */
 
-export default function ProductCardItem({ productType, data }: ProductCardItemProps) {
+export default function ProductCardItem({ productType, data, autoplay = true }: ProductCardItemProps) {
   return (
     <>
       {data.map((item, index) => {
         return (
           <li key={`ProductItem-${index}`}>
             <Link href={`/shop/${productType}/${item._id}`} className="block h-[15.625rem]">
-              <ImagesSwiper data={item} height={'15.625rem'} />
+              <ImagesSwiper data={item} height={'15.625rem'} autoplay={autoplay} />
             </Link>
             <div className="flex gap-1 justify-between mt-4">
               <Link href={`/shop/${productType}/${item._id}`} className="flex-1 min-w-0">

--- a/src/components/product/ProductLayout.tsx
+++ b/src/components/product/ProductLayout.tsx
@@ -14,27 +14,49 @@ interface ProductLayoutProps {
 export default function ProductLayout({ productType }: ProductLayoutProps) {
   const data = [
     {
+      _id: 0,
+      value: 'ALL',
+      link: 'all',
+      image: '/images/products/shortSleeve/5/detail-4.png',
+      alt: 'ALL 상품입니다.',
+    },
+    {
       _id: 1,
+      value: 'BEST',
+      link: 'best',
+      image: '/images/products/shortSleeve/5/detail-1.png',
+      alt: 'SHORT 상품입니다.',
+    },
+    {
+      _id: 2,
+      value: 'SALE',
+      link: 'sale',
+      image: '/images/products/shortSleeve/5/detail-1.png',
+      alt: 'SHORT 상품입니다.',
+    },
+    {
+      _id: 3,
       value: 'SHORT',
       link: 'shortSleeve',
       image: '/images/products/shortSleeve/5/detail-1.png',
       alt: 'SHORT 상품입니다.',
     },
     {
-      _id: 2,
+      _id: 4,
       value: 'LONG',
       link: 'longSleeve',
       image: '/images/products/longSleeve/3/detail-1.png',
       alt: 'LONG 상품입니다.',
     },
-    { _id: 3, value: 'ROBE', link: 'robe', image: '/images/products/robe/3/detail-1.png', alt: 'ROBE 상품입니다.' },
-    { _id: 4, value: 'ACC', link: 'acc', image: '/images/products/acc/1/detail-1.png', alt: 'ACC 상품입니다.' },
+    { _id: 5, value: 'ROBE', link: 'robe', image: '/images/products/robe/3/detail-1.png', alt: 'ROBE 상품입니다.' },
+    { _id: 6, value: 'ACC', link: 'acc', image: '/images/products/acc/1/detail-1.png', alt: 'ACC 상품입니다.' },
   ];
 
   return (
     <>
-      <ul className="grid grid-cols-4 gap-4">
-        {data.map((item, index) => {
+      {/* MOBILE */}
+      <ul className="grid grid-cols-4 gap-4 md:hidden">
+        {data.slice(3).map((item, index) => {
           return (
             <li key={index}>
               <Link href={`/shop/${item.link}`} className="flex flex-col justify-center items-center gap-2">
@@ -46,6 +68,25 @@ export default function ProductLayout({ productType }: ProductLayoutProps) {
                   <Image src={item.image} alt={item.alt} width={100} height={100} />
                 </p>
                 <p className={`${JudsonFont.className}`}>{item.value}</p>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+
+      {/* PC */}
+      <ul className="grid grid-cols-7 gap-4 max-md:hidden">
+        {data.map((item, index) => {
+          return (
+            <li key={index}>
+              <Link href={`/shop/${item.link}`} className="flex flex-col justify-center items-center gap-2">
+                <p
+                  className={`${JudsonFont.className} ${
+                    productType === item.link ? 'bg-(--color-primary)' : 'bg-(--color-gray-250)'
+                  } w-full text-center py-1 text-white`}
+                >
+                  {item.value}
+                </p>
               </Link>
             </li>
           );

--- a/src/hooks/useWindowWidth.ts
+++ b/src/hooks/useWindowWidth.ts
@@ -1,0 +1,18 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { throttle } from 'lodash';
+
+export function useWindowWidth() {
+  const [width, setWidth] = useState(0);
+
+  useEffect(() => {
+    const handleResize = throttle(() => setWidth(window.innerWidth));
+    handleResize();
+    window.addEventListener('resize', handleResize);
+
+    return () => window.removeEventListener('resize', handleResize);
+  });
+
+  return width;
+}


### PR DESCRIPTION
## PR 유형

- [x] ✨ feat: 새로운 기능 추가 / 기존 기능의 주요 변경
- [x] 💄 style: CSS, UI 관련 수정 (기능 변경 없이 스타일만 변경)
- [x] ♻️ refactor: 코드 리팩토링 (동작 변화 없음)
- [x] 🐳 chore: 기타 설정 작업 (패키지 설정, 환경 설정 등)
- [x] 🚚 rename: 파일명, 폴더명 변경

## PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세

기존에 모바일 전용으로 구현되어 있던 Twogether 프로젝트를 PC 환경에서도 자연스럽게 사용할 수 있도록 레이아웃을 확장했습니다.
PC 사용자 경험을 고려하여 여러 UI 요소를 조정하고, 페이지 전반의 여백/정렬/레이아웃 규칙을 재정비했습니다.

- PC 레이아웃 전체 적용
  - 하단 네브바 등은 PC에서 숨김 처리
- Header 구조 개선
  - PC에서는 항상 기본 Header 사용
  - 조건 분리를 위해 **lodash 라이브러리 설치**
- Modal & Alert 배경 개선
  - 기존 모바일 기준으로 설정된 modal/alert 배경을 PC 전체 화면을 덮도록 개선

Before: 
<img width="1552" height="940" alt="image" src="https://github.com/user-attachments/assets/7ed1f839-f503-47f4-a1fe-83e239c5bee1" />
After:
<img width="1552" height="940" alt="image" src="https://github.com/user-attachments/assets/981a0fdb-406a-4cce-be66-97301a482cb2" />

Before:
<img width="1552" height="940" alt="image" src="https://github.com/user-attachments/assets/54d8d66b-0797-4e88-840d-1c891f687ffe" />
After:
<img width="1552" height="940" alt="image" src="https://github.com/user-attachments/assets/29d405a3-d3f8-417d-849f-a46df1cbada6" />
